### PR TITLE
⚠️ workaround: missing argument for parameter 'additionalHeaders' in call

### DIFF
--- a/GTMAppAuth/Sources/KeychainStore/GTMOAuth2Compatibility.swift
+++ b/GTMAppAuth/Sources/KeychainStore/GTMOAuth2Compatibility.swift
@@ -197,7 +197,8 @@ public final class GTMOAuth2Compatibility: NSObject {
       scope: persistenceDictionary[oauth2ScopeKey],
       refreshToken: persistenceDictionary[oauth2RefreshTokenKey],
       codeVerifier: nil,
-      additionalParameters: additionalParameters
+      additionalParameters: additionalParameters,
+      additionalHeaders: nil
     )
     let tokenResponse = OIDTokenResponse(
       request: tokenRequest,

--- a/Package.swift
+++ b/Package.swift
@@ -33,7 +33,7 @@ let package = Package(
   ],
   dependencies: [
     .package(url: "https://github.com/google/gtm-session-fetcher.git", "2.1.0" ..< "4.0.0"),
-    .package(url: "https://github.com/openid/AppAuth-iOS.git", "1.6.0" ..< "2.0.0")
+    .package(url: "https://github.com/mnkd/AppAuth-iOS.git", .branch("fix/vision-os")),
   ],
   targets: [
     .target(


### PR DESCRIPTION
- Fixed missing argument for parameter 'additionalHeaders' in call
- Workaround for building in visionOS

ref:

introduce addtional http headers to OIDTokenRequest
https://github.com/openid/AppAuth-iOS/pull/770
